### PR TITLE
Fixed typo in the getting started docs

### DIFF
--- a/docs/getting_started/docker/1.md
+++ b/docs/getting_started/docker/1.md
@@ -33,30 +33,34 @@ or
 
   * using `glooctl`:
   
-    cat << EOF | glooctl upstream create -f -
-    name: petstore
-    type: service
-    spec:
-      hosts:
-      # gateway ip for the docker network
-      - addr: $(docker inspect docker-compose_default -f '{{ (index .IPAM.Config 0).Gateway }}')
-        port: 1234
-    EOF
+```bash
+cat << EOF | glooctl upstream create -f -
+name: petstore
+type: service
+spec:
+  hosts:
+  # gateway ip for the docker network
+  - addr: $(docker inspect docker-compose_default -f '{{ (index .IPAM.Config 0).Gateway }}')
+    port: 1234
+EOF
+```
 
 
 
 
   * writing directly to disk
 
-    cat > ./_gloo_config/upstreams/petstore.yaml << EOF 
-    name: petstore
-    type: service
-    spec:
-      hosts:
-      # gateway ip for the docker network
-      - addr: $(docker inspect docker-compose_default -f '{{ (index .IPAM.Config 0).Gateway }}')
-        port: 1234
-    EOF
+```bash
+cat > ./_gloo_config/upstreams/petstore.yaml << EOF 
+name: petstore
+type: service
+spec:
+  hosts:
+  # gateway ip for the docker network
+  - addr: $(docker inspect docker-compose_default -f '{{ (index .IPAM.Config 0).Gateway }}')
+    port: 1234
+EOF
+```
 
 
 #### OPTIONAL: View the petstore functions using `glooctl`:


### PR DESCRIPTION
First of all, thanks for all the effort for this project. I'm starting to invest my time in using `qloo` and have started from the `getting started` section. It seemed like the markdown was corrupted and confused me a bit so have decided to create this PR.

This fixes typos related to:

* Code formatting in markdown.
~* The function registered for `Query.pets` was `findPetById` but fixed to `findPets`~

Signed-off-by: Ken Fukuyama <kenfdev@gmail.com>