### PR TITLE
Fix typo on link to qloo

### DIFF
--- a/docs/getting_started/docker/1.md
+++ b/docs/getting_started/docker/1.md
@@ -4,7 +4,7 @@
 
  1. [Docker](https://www.docker.com/)
  1. [Docker-Compose](https://docs.docker.com/compose/)
- 1. [qlooctl](https://github.com/solo-io/qloo/releases)
+ 1. [qloo](https://github.com/solo-io/qloo/releases)
  1. [glooctl](https://github.com/solo-io/glooctl/releases) (optional)
 
 


### PR DESCRIPTION
I've seen a little typo on the link title to download qloo.